### PR TITLE
Workflow update

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -8,11 +8,10 @@
 
 # This workflow has yet to be tested
 
-name: Upload Python Package to PyPI
+name: Upload Python Package to TestPyPI
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -43,13 +42,13 @@ jobs:
 
 
   release-on-pypi:
-    name: Release distribution packages on PyPI
+    name: Release distribution packages on TestPyPI
     needs:
     - build
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    environment: release
+    environment: testpypi
 
     steps:
       - name: Download the distribution packages
@@ -59,3 +58,5 @@ jobs:
           path: dist/
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          url: https://test.pypi.org/legacy/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,7 +8,7 @@
 
 # This workflow has yet to be tested
 
-name: Upload Python Package
+name: Upload Python Package to PyPI
 
 on:
   release:
@@ -19,11 +19,9 @@ permissions:
   contents: read
 
 jobs:
-  release:
+  build:
+    name: Build the disctribution package
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    environment: release
 
     steps:
       - name: Checkout the repository
@@ -40,6 +38,23 @@ jobs:
         run: python3 -m build
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+
+  release-on-pypi:
+    name: Release distribution packages on PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: release
+
+    steps:
+      - name: Download the distribution packages
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,18 +19,19 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     environment: release
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -38,7 +39,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Changes

- Updated actions versions 
- Separated the build and the publish tasks in two jobs, preventing publication if build fails
- Created a second workflow, used to publish on TestPyPI
- Updated trigger for workflow
  - test workflow is trigger with manual launch
  - release workflow can only be trigger through the creation of a release

## Concerns

- maybe release workflow should be able to be triggered manually?
- two workflows can generally be merge into a conditionnal job execution to allow proper CI/CD (triggers on push, conditionnal to tag or branch), but not exactly familiar with it