### PR TITLE
patch:change wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ The plugin is currently in its beta phase and provides access to MonarQ directly
 
 ## References 
 
-Calcul Québec's Wiki provides a lot of information on the plugin, its components and how to use them. You can access it [here](https://docs.alliancecan.ca/wiki/Les_services_quantiques).
+Calcul Québec's Wiki provides a lot of information on the plugin, its components and how to use them. You can access it [here](https://docs.alliancecan.ca/wiki/Services_d%27informatique_quantique).

--- a/doc/for_developers/using_transpiler.ipynb
+++ b/doc/for_developers/using_transpiler.ipynb
@@ -79,7 +79,7 @@
     "\n",
     "This allows you to change transpiling steps, or even add new steps to the processing pipelines.\n",
     "\n",
-    "See [configurations](using_configurations.ipynb) for more information."
+    "See [configurations](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_configurations.ipynb) for more information."
    ]
   },
   {
@@ -90,7 +90,7 @@
     "\n",
     "You can also create new, custom steps to add to the processing pipeline. \n",
     "\n",
-    "See [custom steps](using_custom_steps.ipynb) for mor information."
+    "See [custom steps](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_custom_steps.ipynb) for mor information."
    ]
   }
  ],

--- a/doc/getting_started.ipynb
+++ b/doc/getting_started.ipynb
@@ -70,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1. create a [client](using_client.ipynb) for your device"
+    "1. create a [client](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_client.ipynb) for your device"
    ]
   },
   {
@@ -103,7 +103,7 @@
     "\n",
     "There are 2 optional arguments : \n",
     "1. a number of wire or the exact wires (as an array)\n",
-    "2. a [configuration](./for_developers/using_configurations.ipynb)"
+    "2. a [configuration](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_configurations.ipynb)"
    ]
   },
   {
@@ -128,7 +128,7 @@
    "source": [
     "It should be noted that because you specify wires on gates and on your device does not mean that those wires will be used on MonarQ. \n",
     "\n",
-    "For more information, see [using transpiler](using_transpiler.ipynb)"
+    "For more information, see [using transpiler](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_transpiler.ipynb)"
    ]
   },
   {
@@ -214,11 +214,12 @@
    "source": [
     "## more information \n",
     "\n",
-    "- [clients](using_client.ipynb)\n",
-    "- [processor configs](using_configurations.ipynb)\n",
-    "- [the transpiler](using_transpiler.ipynb)\n",
-    "- [custom processing steps](using_custom_steps.ipynb)\n",
-    "- [custom gates](using_custom_gates.ipynb)"
+    "- [clients](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_client.ipynb)\n",
+    "- [processor configs](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_configurations.ipynb)\n",
+    "- [the transpiler](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_transpiler.ipynb)\n",
+    "- [custom processing steps](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_custom_steps.ipynb)\n",
+    "- [custom gates](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_custom_gates.ipynb)\n"
+    "- [api adapter](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_api_adapter.ipynb)"
    ]
   }
  ],

--- a/doc/getting_started.ipynb
+++ b/doc/getting_started.ipynb
@@ -218,7 +218,7 @@
     "- [processor configs](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_configurations.ipynb)\n",
     "- [the transpiler](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_transpiler.ipynb)\n",
     "- [custom processing steps](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_custom_steps.ipynb)\n",
-    "- [custom gates](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_custom_gates.ipynb)\n"
+    "- [custom gates](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_custom_gates.ipynb)\n", 
     "- [api adapter](https://github.com/calculquebec/pennylane-calculquebec/blob/main/doc/for_developers/using_api_adapter.ipynb)"
    ]
   }


### PR DESCRIPTION
- wiki link was bad. it is now fixed in getting-started, readme and transpiler. 