### PR TITLE
Refactor/isolate sf device

### DIFF
--- a/pennylane_calculquebec/__init__.py
+++ b/pennylane_calculquebec/__init__.py
@@ -1,6 +1,5 @@
 """this is the top level module for the Pennylane Snowflurry plugin. It is used for communicating with MonarQ.
 """
 
-from .pennylane_converter import PennylaneConverter
 from .snowflurry_device import SnowflurryQubitDevice
 from .monarq_device import MonarqDevice

--- a/pennylane_calculquebec/measurements/expectation_value.py
+++ b/pennylane_calculquebec/measurements/expectation_value.py
@@ -1,6 +1,5 @@
 from .measurement_strategy import MeasurementStrategy
 import pennylane as qml
-from juliacall import convert
 import numpy as np
 
 
@@ -10,6 +9,7 @@ class ExpectationValue(MeasurementStrategy):
         super().__init__()
 
     def measure(self, converter, mp, shots):
+        from juliacall import convert
         # FIXME : this measurement does work when the number of qubits measured is not equal to the number of qubits
         #  in the circuit
         # Requires some processing to work with larger matrices

--- a/pennylane_calculquebec/measurements/probabilities.py
+++ b/pennylane_calculquebec/measurements/probabilities.py
@@ -1,5 +1,5 @@
 from .measurement_strategy import MeasurementStrategy
-from juliacall import convert
+
 
 
 class Probabilities(MeasurementStrategy):
@@ -8,6 +8,7 @@ class Probabilities(MeasurementStrategy):
         super().__init__()
 
     def measure(self, converter, mp, shots):
+        from juliacall import convert
         converter.remove_readouts()
         wires_list = mp.wires.tolist()
         if len(wires_list) == 0:

--- a/tests/test_pennylaneConverter.py
+++ b/tests/test_pennylaneConverter.py
@@ -1,6 +1,6 @@
 import pytest
 from pennylane_calculquebec import measurements
-from pennylane_calculquebec import PennylaneConverter
+from pennylane_calculquebec.pennylane_converter import PennylaneConverter
 import pennylane as qml
 import numpy as np
 from pennylane.tape import QuantumTape


### PR DESCRIPTION
Moved any references to `juliacall` inside functions, avoiding unintended import from `juliacall` upon plugin initialisation.