### PR TITLE
add qml probs to monarq device

### DIFF
--- a/pennylane_calculquebec/monarq_device.py
+++ b/pennylane_calculquebec/monarq_device.py
@@ -137,6 +137,15 @@ class MonarqDevice(Device):
 
 
     def _measure(self, tape : QuantumTape):
+        """
+        sends job to Monarq and returns value, converted to required measurement type
+
+        Args : 
+            tape (QuantumTape) : the tape from which to get results
+        
+        Returns :
+            a result, which format can change according to the measurement process
+        """
         if len(tape.measurements) != 1:
             raise DeviceException("Multiple measurements not supported")
         meas = type(tape.measurements[0]).__name__

--- a/pennylane_calculquebec/utility/debug.py
+++ b/pennylane_calculquebec/utility/debug.py
@@ -28,7 +28,7 @@ def compute_expval(probabilities):
 
 def counts_to_probs(counts : dict):
     max_count = sum(counts.values())
-    all_labels = get_labels(2 ** len(counts.keys()[0]) - 1)
+    all_labels = get_labels(2 ** len(list(counts.keys())[0]) - 1)
     return [(counts[label] if label in counts else 0) / max_count for label in all_labels]
 
 def remove_global_phase(matrix):

--- a/tests/test_monarq_device.py
+++ b/tests/test_monarq_device.py
@@ -107,7 +107,7 @@ def test_measure():
         
         # invalid measurement
         quantum_tape.measurements.append(qml.sample())
-        with pytest.raises(Exception):
+        with pytest.raises(DeviceException):
             _ = MonarqDevice._measure(None, quantum_tape)
         job.assert_not_called()
 
@@ -128,5 +128,5 @@ def test_measure():
         
         # too many measurements
         quantum_tape.measurements.append(qml.counts())
-        with pytest.raises(Exception):
+        with pytest.raises(DeviceException):
             _ = MonarqDevice._measure(None, quantum_tape)

--- a/tests/test_monarq_device.py
+++ b/tests/test_monarq_device.py
@@ -124,6 +124,7 @@ def test_measure():
         counts = MonarqDevice._measure(None, quantum_tape)
         assert counts == expected_counts
         
+        # since the method has been called one time before, the call count is incremented to 2
         assert job.call_count == 2
         
         # too many measurements


### PR DESCRIPTION
- add capacity to use qml.probs when using monarq device (converts it from counts
- change code to promote extendability for future adds
- add tests for probs