### PR TITLE
print configs + refactor for usability

### DIFF
--- a/pennylane_calculquebec/processing/config/__init__.py
+++ b/pennylane_calculquebec/processing/config/__init__.py
@@ -7,4 +7,6 @@ from .processing_config \
     NoPlaceNoRouteConfig, \
     MonarqDefaultConfigNoBenchmark, \
     EmptyConfig, \
-    FakeMonarqConfig
+    FakeMonarqConfig, \
+    PrintDefaultConfig, \
+    PrintNoPlaceNoRouteConfig

--- a/pennylane_calculquebec/processing/steps/__init__.py
+++ b/pennylane_calculquebec/processing/steps/__init__.py
@@ -11,4 +11,4 @@ from .readout_error_mitigation import MatrixReadoutMitigation, IBUReadoutMitigat
 from .decompose_readout import DecomposeReadout
 from .gate_noise_simulation import GateNoiseSimulation
 from .readout_noise_simulation import ReadoutNoiseSimulation
-from .print_steps import PrintResults, PrintTape
+from .print_steps import PrintResults, PrintTape, PrintWires

--- a/pennylane_calculquebec/processing/steps/print_steps.py
+++ b/pennylane_calculquebec/processing/steps/print_steps.py
@@ -9,3 +9,8 @@ class PrintResults(PostProcStep):
     def execute(self, tape, results):
         print(results)
         return results
+    
+class PrintWires(PreProcStep):
+    def execute(self, tape):
+        print(*[w for w in tape.wires])
+        return tape

--- a/tests/test_processing_config.py
+++ b/tests/test_processing_config.py
@@ -1,5 +1,22 @@
-from pennylane_calculquebec.processing.config import ProcessingConfig, MonarqDefaultConfig, MonarqDefaultConfigNoBenchmark, NoPlaceNoRouteConfig, EmptyConfig, FakeMonarqConfig
-from pennylane_calculquebec.processing.steps import DecomposeReadout, CliffordTDecomposition, ASTAR, ISMAGS, Swaps, IterativeCommuteAndMerge, MonarqDecomposition, GateNoiseSimulation, ReadoutNoiseSimulation
+from pennylane_calculquebec.processing.config import (ProcessingConfig, 
+                                                      MonarqDefaultConfig, 
+                                                      MonarqDefaultConfigNoBenchmark, 
+                                                      NoPlaceNoRouteConfig, 
+                                                      EmptyConfig, 
+                                                      FakeMonarqConfig,
+                                                      PrintNoPlaceNoRouteConfig, 
+                                                      PrintDefaultConfig)
+from pennylane_calculquebec.processing.steps import (DecomposeReadout, 
+                                                    CliffordTDecomposition,
+                                                    ASTAR, 
+                                                    ISMAGS, 
+                                                    Swaps, 
+                                                    IterativeCommuteAndMerge, 
+                                                    MonarqDecomposition, 
+                                                    GateNoiseSimulation, 
+                                                    ReadoutNoiseSimulation,
+                                                    PrintTape,
+                                                    PrintWires)
 
 def test_processing_config():
     config = ProcessingConfig(1, 2, 3)
@@ -36,3 +53,25 @@ def test_presets():
     
     for step in default.steps:
         assert any(type(def_step) == type(step) for def_step in config.steps)
+    assert any(type(def_step) == type(GateNoiseSimulation(False)) for def_step in config.steps)
+    assert any(type(def_step) == type(ReadoutNoiseSimulation(False)) for def_step in config.steps)
+
+    # print default config is the same as default + prints at start and end
+    config = PrintDefaultConfig()
+    for step in default.steps:
+        assert any(type(def_step) == type(step) for def_step in config.steps)
+    assert any(type(def_step) == type(PrintWires()) for def_step in config.steps)
+
+    config = PrintDefaultConfig(False)
+    assert any(type(def_step) == type(PrintTape()) for def_step in config.steps)
+    
+    # print no place no route config is the same as default + prints at start and end
+    config = PrintNoPlaceNoRouteConfig()
+    no_place_no_route = NoPlaceNoRouteConfig()
+    for step in no_place_no_route.steps:
+        assert any(type(def_step) == type(step) for def_step in config.steps)
+    assert any(type(def_step) == type(PrintWires()) for def_step in config.steps)
+
+    config = PrintNoPlaceNoRouteConfig(False)
+    assert any(type(def_step) == type(PrintTape()) for def_step in config.steps)
+    


### PR DESCRIPTION
two new presets that print the circuit before and after compilation : 
- one that is the same as the default config
- one that is the same as the no place no route config

also, I have done a refactor in the preset file, for the presets to show inline doc when used