### PR TITLE
fix readout error simulation and mitigation

### DIFF
--- a/pennylane_calculquebec/processing/steps/readout_noise_simulation.py
+++ b/pennylane_calculquebec/processing/steps/readout_noise_simulation.py
@@ -6,7 +6,7 @@ from pennylane_calculquebec.processing.interfaces import PostProcStep
 from pennylane_calculquebec.monarq_data import get_readout_noise_matrices
 import pennylane as qml
 import numpy as np
-from pennylane_calculquebec.utility.debug import get_labels
+from pennylane_calculquebec.utility.debug import get_labels, get_measurement_wires
 from pennylane_calculquebec.utility.noise import readout_error, TypicalBenchmark
 
 class ReadoutNoiseSimulation(PostProcStep):
@@ -34,7 +34,7 @@ class ReadoutNoiseSimulation(PostProcStep):
 
         readout_matrix = np.identity(1)
         
-        wires = [w for w in tape.wires]
+        wires = get_measurement_wires(tape)
         
         for wire in wires:
             readout_matrix = np.kron(readout_matrix, readout_error_matrices[wire])

--- a/pennylane_calculquebec/utility/debug.py
+++ b/pennylane_calculquebec/utility/debug.py
@@ -87,3 +87,10 @@ def get_labels(up_to : int):
     
     num = int(np.log2(up_to)) + 1
     return [format(i, f"0{num}b") for i in range(up_to + 1)]
+
+def get_measurement_wires(tape : QuantumTape):
+    measurement_wires = []
+    for mp in tape.measurements:
+        measurement_wires += list(mp.wires)
+    return measurement_wires
+    

--- a/tests/test_debug_utility.py
+++ b/tests/test_debug_utility.py
@@ -86,3 +86,21 @@ def test_get_labels():
     expected = ["000", "001", "010", "011", "100", "101", "110"]
     result = debug.get_labels(test_value)
     assert all(a == b for a, b in zip(expected, result))
+
+
+def test_get_measurement_wires():
+    class Tape:
+        def __init__(self, wires, measures):
+            self.wires = wires
+            self.measurements = measures
+    
+    class Measure:
+        def __init__(self, wires):
+            self.wires = wires
+
+    tape = Tape([0, 1, 2, 3], [Measure([0]), Measure([1]), Measure([3])])
+    expected = [0, 1, 3]
+    result = debug.get_measurement_wires(tape)
+
+    assert len(expected) == len(result) and all(a in result for a in expected)
+

--- a/tests/test_readout_mitigation.py
+++ b/tests/test_readout_mitigation.py
@@ -116,11 +116,12 @@ def test_tensor_product_calibration(mock_qubits_couplers):
     assert all(abs(a - b) < TOLERANCE for a, b in zip(expected.flatten(), results.flatten()))
 
 def test_matrix_readout_mitigation_full(mock_qubits_couplers):
+    TOLERANCE = 5
     from pennylane_calculquebec.processing.steps import ReadoutNoiseSimulation
     typical = (TypicalBenchmark.readout0, TypicalBenchmark.readout1)
     mock_qubits_couplers.return_value = qubits_couplers(typical, typical, typical, typical)
     
-    expected = {"0000" : 500, "1111" : 500}
+    expected = {"000" : 500, "111" : 500}
     tape = Tape([0, 1, 2, 3], [Measure([0]), Measure([2]), Measure([3])])
 
     sim = ReadoutNoiseSimulation(False)
@@ -130,7 +131,7 @@ def test_matrix_readout_mitigation_full(mock_qubits_couplers):
     
     results = step.execute(tape, simulated_noise)
     
-    for key in mitigation.all_combinations(4):
+    for key in mitigation.all_combinations(3):
         if key not in expected:
             assert abs(results[key]) < TOLERANCE
             continue
@@ -141,7 +142,7 @@ def test_ibu_readout_mitigation_full(mock_qubits_couplers):
     typical = (TypicalBenchmark.readout0, TypicalBenchmark.readout1)
     mock_qubits_couplers.return_value = qubits_couplers(typical, typical, typical, typical)
     
-    expected = {"0000" : 500, "1111" : 500}
+    expected = {"000" : 500, "111" : 500}
     tape = Tape([0, 1, 2, 3], [Measure([0]), Measure([2]), Measure([3])])
 
     sim = ReadoutNoiseSimulation(False)
@@ -151,7 +152,7 @@ def test_ibu_readout_mitigation_full(mock_qubits_couplers):
     
     results = step.execute(tape, simulated_noise)
     
-    for key in mitigation.all_combinations(4):
+    for key in mitigation.all_combinations(3):
         if key not in expected:
             assert abs(results[key]) < TOLERANCE
             continue

--- a/tests/test_sf_conditional_import.py
+++ b/tests/test_sf_conditional_import.py
@@ -1,6 +1,22 @@
 from unittest.mock import patch
 import pytest
 
+@pytest.fixture(autouse=True)
+def setup_module():
+    import sys
+    sf = "pennylane_calculquebec.snowflurry_device"
+    plc = "pennylane_calculquebec.pennylane_converter"
+    plcq = "pennylane_calculquebec"
+
+    if sf in sys.modules:
+        del sys.modules[sf]
+    
+    if plc in sys.modules:
+        del sys.modules[plc]
+    
+    if plcq in sys.modules:
+        del sys.modules[plcq]
+
 @pytest.fixture
 def mock_snowflurry_device():
     with patch("pennylane_calculquebec.snowflurry_device.SnowflurryQubitDevice") as mock:


### PR DESCRIPTION
readout error mitigation and simulation considered all the wires of the circuits to be observed, which returned bad results

Using only measured wires fixes the problem

Also added tests to make sure this is caught if it happens again