### PR TITLE
isolate noise simulation from procesing configs

### DIFF
--- a/pennylane_calculquebec/base_device.py
+++ b/pennylane_calculquebec/base_device.py
@@ -31,7 +31,7 @@ class BaseDevice(Device):
         super().__init__(wires, shots)
 
         if processing_config is None:
-            processing_config = self.default_processing_config
+            processing_config = self.default_processing_config()
         self._processing_config = processing_config
 
         if client is not None:
@@ -88,8 +88,4 @@ class BaseDevice(Device):
 
 
     def _measure(self, tape : QuantumTape):
-        raise NotImplementedError()
-    
-    @property
-    def default_processing_config(self):
         raise NotImplementedError()

--- a/pennylane_calculquebec/base_device.py
+++ b/pennylane_calculquebec/base_device.py
@@ -29,9 +29,6 @@ class BaseDevice(Device):
     
     def __init__(self, wires = None, shots = None, client = None, processing_config = None):
         super().__init__(wires, shots)
-
-        if processing_config is None:
-            processing_config = self.default_processing_config()
         self._processing_config = processing_config
 
         if client is not None:

--- a/pennylane_calculquebec/monarq_device.py
+++ b/pennylane_calculquebec/monarq_device.py
@@ -44,7 +44,7 @@ class MonarqDevice(BaseDevice):
                  wires = None, 
                  shots = None,  
                  client : ApiClient = None,
-                 processing_config : ProcessingConfig = None) -> None:
+                 processing_config : ProcessingConfig = MonarqDefaultConfig()) -> None:
 
         super().__init__(wires, shots, client, processing_config)
 
@@ -81,6 +81,3 @@ class MonarqDevice(BaseDevice):
 
         return measurement_method(results)
     
-    @property
-    def default_processing_config(self):
-        return MonarqDefaultConfig()

--- a/pennylane_calculquebec/processing/steps/optimization.py
+++ b/pennylane_calculquebec/processing/steps/optimization.py
@@ -98,7 +98,7 @@ class IterativeCommuteAndMerge(Optimize):
         if operation.basis != "Y":
             raise ValueError("Operation must be in the Y basis")
         rot_angles = operation.single_qubit_rot_angles()
-        return [qml.RZ(np.pi/2, operation.wires), qml.RX(rot_angles[1], operation.wires), qml.RZ(-np.pi/2, operation.wires)]
+        return [qml.RZ(-np.pi/2, operation.wires), qml.RX(rot_angles[1], operation.wires), qml.RZ(np.pi/2, operation.wires)]
 
     @staticmethod
     def get_rid_of_y_rotations(tape : QuantumTape):

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -67,7 +67,7 @@ def test_optimize_cu():
     new_tape = CliffordTDecomposition().execute(tape)
     new_tape = IterativeCommuteAndMerge().execute(new_tape)
     
-    assert len(new_tape.operations) == 51
+    assert len(new_tape.operations) == 53
     
     
     mat1 = reduce(lambda i, s: i @ s.matrix(wire_order=tape.wires), tape.operations, np.identity(1 << len(tape.wires)))
@@ -122,9 +122,9 @@ def test_Y_to_ZXZ():
     
     op = qml.RY(-np.pi/5, 0)
     result = IterativeCommuteAndMerge.Y_to_ZXZ(op)
-    assert result[0] == qml.RZ(np.pi/2, 0)
+    assert result[0] == qml.RZ(-np.pi/2, 0)
     assert result[1] == qml.RX(-np.pi/5, 0)
-    assert result[2] == qml.RZ(-np.pi/2, 0)
+    assert result[2] == qml.RZ(np.pi/2, 0)
     
 def test_get_rid_of_Y_rotations():
     with patch("pennylane_calculquebec.processing.steps.optimization.IterativeCommuteAndMerge.Y_to_ZXZ") as Y_to_ZXZ_mock:
@@ -153,4 +153,4 @@ def test_get_rid_of_Y_rotations():
     # y basis rotation
     tape = QuantumTape([qml.RY(np.pi/5, 0)])
     result = IterativeCommuteAndMerge.get_rid_of_y_rotations(tape)
-    assert result.operations == [qml.RZ(np.pi/2, 0), qml.RX(np.pi/5, 0), qml.RZ(-np.pi/2, 0)]
+    assert result.operations == [qml.RZ(-np.pi/2, 0), qml.RX(np.pi/5, 0), qml.RZ(np.pi/2, 0)]


### PR DESCRIPTION
Le fait que la simulation de bruit se faisait dans les étapes de processing faisait en sorte qu'aucune autre config ne pouvait être utilisé que FakeMonarqConfig. 

Le bruit a donc été extrait des configs de manière à permettre aux utilisateurs d'utiliser d'autres configs que la config de simulation. 

Une erreur de décomposition a aussi été corrigée dans l'étape d'optimisation