### PR TITLE
Ajout d'une Action Github pour l'analyse statique de code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Format code with Black
+        uses: psf/black@stable
+        with:
+          options: "--verbose"
+          jupyter: 'true'
+          src: "./doc ./pennylane_calculquebec ./tests"
+
+      - name: Create PR with changes
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "Format Python code with psf/black"
+          body: |
+            There appear to be some python formatting errors in ${{ github.sha }}. This pull request
+            uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
+          base: ${{ github.head_ref }}
+          branch: actions/black


### PR DESCRIPTION
## Description

Ajoute un workflow pour automatiser l'analyse statique de code. Lorsque du code est poussé sur le répertoire et ne respecte pas les normes PEP8, une PR est automatiquement créer sur la branche ou le commit coupable avec les changements requis.

## Problème résolu / Fonctionnalité ajoutée

Absence d'analyse statique sur le répertoire de code

## Comment tester

Pousser du code qui ne respecte pas la norme 😆 

## Numéro de l'issue associée

resolve #152 
