### PR TITLE
Workflow/lint update

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,10 @@ jobs:
 
       - name: Format code with Black
         uses: psf/black@stable
+        id: black
+        continue-on-error: true
         with:
-          options: "--verbose"
+          options: "--verbose --check"
           jupyter: 'true'
           src: "./doc ./pennylane_calculquebec ./tests"
 
@@ -26,3 +28,16 @@ jobs:
             uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
           base: ${{ github.head_ref }}
           branch: reformat/${{ github.ref_name }}
+
+      - name: Fail if files are formatted by psf/black
+        if: ${{ steps.black.outputs.exit_code == 1 }}
+        run: |
+          echo "There are formatting issues in the code. Please review the pull request created by psf/black."
+          exit 1
+
+      - name: Fail if psf/black fails
+        if: ${{ steps.black.outputs.exit_code != 0 }}
+        run: |
+          echo "psf/black could not be run successfully. Please check the logs for more details."
+          exit 1
+      

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,12 +22,13 @@ jobs:
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@v7
         with:
-          title: "Format Python code with psf/black"
+          title: Format code in ${{github.head_ref}} branch
           body: |
-            There appear to be some python formatting errors in ${{ github.sha }}. This pull request
-            uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.
+            There appear to be some python formatting errors in ${{ github.ref_name }}. This pull request
+            uses the [psf/black](https://github.com/psf/black) formatter to fix these issues. Please review the 
+            changes and merge if appropriate.
           base: ${{ github.head_ref }}
-          branch: reformat/${{ github.ref_name }}
+          branch: reformat/${{ github.head_ref }}
 
       - name: Fail if files are formatted by psf/black
         if: ${{ steps.black.outputs.exit_code == 1 }}


### PR DESCRIPTION
## Description

Mise à jour du workflow de linting:

- Description et titre plus spécifique
- Ne se déclenche que sur les PR et non les commits individuels
- Le check sur la PR original échoue si du reformattage est nécessaire

## Problème résolu / Fonctionnalité ajoutée

À la création d'une PR, le workflow était déclenché par les événements `pull_request` et `push`, chacun avec des références différentes, ce qui résultait en des duplicats des PR automatisées.

## Comment tester

1. Créer une PR avec du code non-conforme
2. Valider qu'une PR automatique a été générée
3. Faire un autre commit avec du code non-conforme
4. Valider que la PR existante est mise à jour et qu'aucune autre PR n'a été créée automatiquement

## Autres informations

- https://docs.github.com/en/actions/reference/accessing-contextual-information-about-workflow-runs#github-context
- https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#autopep8
- https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#check