### PR TITLE
Remplacement de l'utilisation de `project_name` par `project_id`

### DIFF
--- a/pennylane_calculquebec/API/adapter.py
+++ b/pennylane_calculquebec/API/adapter.py
@@ -268,31 +268,21 @@ class ApiAdapter(object):
     @retry(3)
     def post_job(
         circuit: dict,
-        machine_name: str,
-        circuit_name: str,
         shot_count: int = 1,
-        project_name: str = "",
-        project_id: str = "",
     ) -> requests.Response:
         """
         Post a new job for running a specific circuit a certain number of times on given machine (machine name stored in client)
 
         Args:
             circuit (dict) : The dictionary representation of a circuit
-            machine_name (str) : The machine on which to run the circuit
-            circuit_name (str) : The circuit name
             shot_count (int) : The number of shots. default is 1
-            project_name (str) : The project name
-            project_id (str) : The project id is optional, if not provided, it will be fetched using the project name.
 
         Returns:
             Response : The response of the /job post request
         """
-        project_id = (
-            ApiAdapter.get_project_id_by_name(project_name)
-            if project_name
-            else project_id
-        )
+        project_id = ApiAdapter.instance().client.project_id
+        circuit_name = ApiAdapter.instance().client.circuit_name
+        machine_name = ApiAdapter.instance().client.machine_name
         body = ApiUtility.job_body(
             circuit, circuit_name, project_id, machine_name, shot_count
         )

--- a/pennylane_calculquebec/API/adapter.py
+++ b/pennylane_calculquebec/API/adapter.py
@@ -126,6 +126,10 @@ class ApiAdapter(object):
             client.user, client.access_token, client.realm
         )
         cls._instance.client = client
+        if client.project_name != "":
+            cls._instance.client.project_id = ApiAdapter.get_project_id_by_name(
+                client.project_name
+            )
 
         cls._qubits_and_couplers: dict = None
         cls._machine: dict = None

--- a/pennylane_calculquebec/API/adapter.py
+++ b/pennylane_calculquebec/API/adapter.py
@@ -266,7 +266,7 @@ class ApiAdapter(object):
 
     @staticmethod
     @retry(3)
-    def create_job(
+    def post_job(
         circuit: dict,
         machine_name: str,
         circuit_name: str,

--- a/pennylane_calculquebec/API/client.py
+++ b/pennylane_calculquebec/API/client.py
@@ -85,7 +85,7 @@ class ApiClient:
         self.machine_name = machine_name
         self._project_name = project_name or ""
         self._project_id = project_id or ""
-        self._circuit_name = circuit_name or ""
+        self._circuit_name = circuit_name or "none"
 
 
 class CalculQuebecClient(ApiClient):

--- a/pennylane_calculquebec/API/client.py
+++ b/pennylane_calculquebec/API/client.py
@@ -37,13 +37,20 @@ class ApiClient:
         project_id (str) : the ID of the project
     """
 
-    host: str
-    user: str
-    access_token: str
-    realm: str
-    machine_name: str
-    project_name: str
-    project_id: str
+    @property
+    def project_name(self):
+        """Returns the project name."""
+        return self._project_name
+
+    @property
+    def project_id(self):
+        """Returns the project ID."""
+        return self._project_id
+
+    @project_id.setter
+    def project_id(self, value: str):
+        """Sets the project ID."""
+        self._project_id = value
 
     def __init__(
         self,
@@ -70,8 +77,8 @@ class ApiClient:
         self.access_token = access_token
         self.realm = realm
         self.machine_name = machine_name
-        self.project_name = project_name or ""
-        self.project_id = project_id or ""
+        self._project_name = project_name or ""
+        self._project_id = project_id or ""
 
 
 class CalculQuebecClient(ApiClient):

--- a/pennylane_calculquebec/API/client.py
+++ b/pennylane_calculquebec/API/client.py
@@ -52,6 +52,11 @@ class ApiClient:
         """Sets the project ID."""
         self._project_id = value
 
+    @property
+    def circuit_name(self):
+        """Returns the circuit name."""
+        return self._circuit_name
+
     def __init__(
         self,
         host: str,
@@ -61,6 +66,7 @@ class ApiClient:
         machine_name: str,
         project_name: str = None,
         project_id: str = None,
+        circuit_name: str = None,
     ):
         # Validation of project_name and project_id parameters
         if project_name is None and project_id is None:
@@ -79,6 +85,7 @@ class ApiClient:
         self.machine_name = machine_name
         self._project_name = project_name or ""
         self._project_id = project_id or ""
+        self._circuit_name = circuit_name or ""
 
 
 class CalculQuebecClient(ApiClient):
@@ -96,10 +103,24 @@ class CalculQuebecClient(ApiClient):
     """
 
     def __init__(
-        self, host, user, token, machine_name, project_name=None, project_id=None
+        self,
+        host,
+        user,
+        token,
+        machine_name,
+        project_name=None,
+        project_id=None,
+        circuit_name=None,
     ):
         super().__init__(
-            host, user, token, "calculqc", machine_name, project_name, project_id
+            host,
+            user,
+            token,
+            "calculqc",
+            machine_name,
+            project_name,
+            project_id,
+            circuit_name,
         )
 
 
@@ -116,5 +137,21 @@ class MonarqClient(CalculQuebecClient):
 
     """
 
-    def __init__(self, host, user, access_token, project_name=None, project_id=None):
-        super().__init__(host, user, access_token, "yamaska", project_name, project_id)
+    def __init__(
+        self,
+        host,
+        user,
+        access_token,
+        project_name=None,
+        project_id=None,
+        circuit_name=None,
+    ):
+        super().__init__(
+            host,
+            user,
+            access_token,
+            "yamaska",
+            project_name,
+            project_id,
+            circuit_name,
+        )

--- a/pennylane_calculquebec/API/client.py
+++ b/pennylane_calculquebec/API/client.py
@@ -35,6 +35,7 @@ class ApiClient:
         machine_name (str) : the name of the machine
         project_name (str) : the name of the project
         project_id (str) : the ID of the project
+        circuit_name (str) : the name of the circuit to use for the job
     """
 
     @property
@@ -57,35 +58,49 @@ class ApiClient:
         """Returns the circuit name."""
         return self._circuit_name
 
+    @circuit_name.setter
+    def circuit_name(self, value: str):
+        """Sets the circuit name."""
+        self._circuit_name = value
+
+    @property
+    def machine_name(self):
+        """Returns the machine name."""
+        return self._machine_name
+
+    @machine_name.setter
+    def machine_name(self, value: str):
+        """Sets the machine name."""
+        self._machine_name = value
+
     def __init__(
         self,
         host: str,
         user: str,
         access_token: str,
         realm: str,
-        machine_name: str,
-        project_name: str = None,
-        project_id: str = None,
-        circuit_name: str = None,
+        project_name: str = "",
+        project_id: str = "",
+        circuit_name: str = "none",
     ):
         # Validation of project_name and project_id parameters
-        if project_name is None and project_id is None:
+        if project_name == "" and project_id == "":
             raise ProjectParameterError(
                 "Either project_name or project_id must be provided"
             )
 
-        if project_name is not None and project_id is not None:
+        if project_name != "" and project_id != "":
             # If both are provided, use only project_id
-            project_name = None
+            project_name = ""
 
         self.host = host
         self.user = user
         self.access_token = access_token
         self.realm = realm
-        self.machine_name = machine_name
-        self._project_name = project_name or ""
-        self._project_id = project_id or ""
-        self._circuit_name = circuit_name or "none"
+        self._machine_name = ""
+        self._project_name = project_name
+        self._project_id = project_id
+        self._circuit_name = circuit_name
 
 
 class CalculQuebecClient(ApiClient):
@@ -96,9 +111,9 @@ class CalculQuebecClient(ApiClient):
         host (str) : the server address for the machine
         user (str) : the users identifier
         access_token (str) : the unique access key provided to the user
-        machine_name (str) : the name of the machine
         project_name (str) : the name of the project (exclusive with project_id)
         project_id (str) : the ID of the project (exclusive with project_name)
+        circuit_name (str) : the name of the circuit to use for the job
 
     """
 
@@ -107,17 +122,15 @@ class CalculQuebecClient(ApiClient):
         host,
         user,
         token,
-        machine_name,
-        project_name=None,
-        project_id=None,
-        circuit_name=None,
+        project_name="",
+        project_id="",
+        circuit_name="",
     ):
         super().__init__(
             host,
             user,
             token,
             "calculqc",
-            machine_name,
             project_name,
             project_id,
             circuit_name,
@@ -134,23 +147,25 @@ class MonarqClient(CalculQuebecClient):
         access_token (str) : the unique access key provided to the user
         project_name (str) : the name of the project (exclusive with project_id)
         project_id (str) : the ID of the project (exclusive with project_name)
+        circuit_name (str) : the name of the circuit to use for the job
 
     """
+
+    # FIXME : deprecate this class in favor of CalculQuebecClient
 
     def __init__(
         self,
         host,
         user,
         access_token,
-        project_name=None,
-        project_id=None,
-        circuit_name=None,
+        project_name="",
+        project_id="",
+        circuit_name="",
     ):
         super().__init__(
             host,
             user,
             access_token,
-            "yamaska",
             project_name,
             project_id,
             circuit_name,

--- a/pennylane_calculquebec/API/job.py
+++ b/pennylane_calculquebec/API/job.py
@@ -30,8 +30,6 @@ class Job:
 
     Args:
         circuit (QuantumTape) : the circuit you want to execute
-        machine_name (str) : the name of the machine
-        circuit_name (str) : the name of the circuit, defaults to "default"
     """
 
     started: Callable[[int], None]
@@ -41,23 +39,11 @@ class Job:
     def __init__(
         self,
         circuit: QuantumTape,
-        machine_name: str,
-        circuit_name: str,
-        project_name: str,
     ):
         self.started = None
         self.status_changed = None
         self.completed = None
-        if circuit_name is None:
-            raise JobException("you must provide a circuit name")
-
-        if project_name is None:
-            raise JobException("you must provide a project name")
-
         self.circuit_dict = ApiUtility.convert_circuit(circuit)
-        self.machine_name = machine_name
-        self.circuit_name = circuit_name
-        self.project_name = project_name
         self.shots = circuit.shots.total_shots
 
     def run(self, max_tries: int = 2**15) -> dict:
@@ -74,9 +60,6 @@ class Job:
         try:
             response = ApiAdapter.post_job(
                 self.circuit_dict,
-                self.machine_name,
-                self.circuit_name,
-                self.project_name,
                 self.shots,
             )
         except:

--- a/pennylane_calculquebec/API/job.py
+++ b/pennylane_calculquebec/API/job.py
@@ -72,7 +72,7 @@ class Job:
 
         response = None
         try:
-            response = ApiAdapter.create_job(
+            response = ApiAdapter.post_job(
                 self.circuit_dict,
                 self.machine_name,
                 self.circuit_name,

--- a/pennylane_calculquebec/base_device.py
+++ b/pennylane_calculquebec/base_device.py
@@ -47,7 +47,8 @@ class BaseDevice(Device):
 
         if client is not None:
             self._client = client
-            ApiAdapter.initialize(client)
+            self._client.machine_name = self.machine_name
+            ApiAdapter.initialize(self._client)
 
     def preprocess(
         self,

--- a/pennylane_calculquebec/base_device.py
+++ b/pennylane_calculquebec/base_device.py
@@ -38,29 +38,11 @@ class BaseDevice(Device):
     _processing_config: ProcessingConfig
 
     @property
-    def circuit_name(self):
-        return self._circuit_name
-
-    @circuit_name.setter
-    def circuit_name(self, value):
-        self._circuit_name = value
-
-    @property
-    def project_name(self):
-        return self._project_name
-
-    @project_name.setter
-    def project_name(self, value):
-        self._project_name = value
-
-    @property
     def processing_config(self):
         return self._processing_config
 
     def __init__(self, wires=None, shots=None, client=None, processing_config=None):
         super().__init__(wires, shots)
-        self._circuit_name = None
-        self._project_name = None
         self._processing_config = processing_config
 
         if client is not None:

--- a/pennylane_calculquebec/monarq_device.py
+++ b/pennylane_calculquebec/monarq_device.py
@@ -119,12 +119,7 @@ class MonarqDevice(BaseDevice):
             ):
                 raise DeviceException("Measurement not supported")
 
-            job = Job(
-                tape,
-                self.machine_name,
-                self._client.circuit_name,
-                self._client.project_id,
-            )
+            job = Job(tape)
             job.started = self.job_started
             job.status_changed = self.job_status_changed
             job.completed = self.job_completed

--- a/pennylane_calculquebec/monarq_device.py
+++ b/pennylane_calculquebec/monarq_device.py
@@ -119,7 +119,12 @@ class MonarqDevice(BaseDevice):
             ):
                 raise DeviceException("Measurement not supported")
 
-            job = Job(tape, self.machine_name, self.circuit_name, self.project_name)
+            job = Job(
+                tape,
+                self.machine_name,
+                self._client.circuit_name,
+                self._client.project_id,
+            )
             job.started = self.job_started
             job.status_changed = self.job_status_changed
             job.completed = self.job_completed

--- a/tests/test_api_adapter.py
+++ b/tests/test_api_adapter.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from pennylane_calculquebec.utility.api import ApiUtility, keys
 from datetime import datetime, timedelta
 
-client = MonarqClient("test", "test", "test")
+client = MonarqClient("test", "test", "test", project_id="123")
 
 
 # ------------ MOCKS ----------------------

--- a/tests/test_api_adapter.py
+++ b/tests/test_api_adapter.py
@@ -163,17 +163,17 @@ def test_get_benchmark(
         benchmark = ApiAdapter.get_benchmark("yamaska")
 
 
-def test_create_job(mock_job_body, mock_get_project_id_by_name, mock_requests_post):
+def test_post_job(mock_job_body, mock_get_project_id_by_name, mock_requests_post):
     ApiAdapter.initialize(client)
 
     mock_get_project_id_by_name.return_value = 0
 
     mock_requests_post.return_value = Res(200, 42)
-    assert ApiAdapter.create_job({}, "yamaska", "circuit", "project").text == 42
+    assert ApiAdapter.post_job({}, "yamaska", "circuit", "project").text == 42
 
     mock_requests_post.return_value = Res(400, '{"error" : 42}')
     with pytest.raises(Exception):
-        ApiAdapter.create_job({}, "yamaska", "circuit", "project")
+        ApiAdapter.post_job({}, "yamaska", "circuit", "project")
 
 
 def test_list_jobs(mock_requests_get):

--- a/tests/test_api_adapter.py
+++ b/tests/test_api_adapter.py
@@ -168,12 +168,12 @@ def test_post_job(mock_job_body, mock_get_project_id_by_name, mock_requests_post
 
     mock_get_project_id_by_name.return_value = 0
 
-    mock_requests_post.return_value = Res(200, 42)
-    assert ApiAdapter.post_job({}, "yamaska", "circuit", "project").text == 42
+    mock_requests_post.return_value = Res(200, "{'jobID': 'a_job_uuid'}")
+    assert ApiAdapter.post_job(circuit={}).text == "{'jobID': 'a_job_uuid'}"
 
     mock_requests_post.return_value = Res(400, '{"error" : 42}')
     with pytest.raises(Exception):
-        ApiAdapter.post_job({}, "yamaska", "circuit", "project")
+        ApiAdapter.post_job(circuit={})
 
 
 def test_list_jobs(mock_requests_get):

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -257,37 +257,17 @@ class TestMonarqClient:
 
 
 class TestProjectParameterValidation:
-    """Test cases for project_name and project_id validation rules across all clients."""
+    """Test cases for project_name and project_id validation rules at Parent class level."""
 
-    @pytest.mark.parametrize(
-        "client_class,params",
-        [
-            (
-                ApiClient,
-                {
-                    "host": "host",
-                    "user": "user",
-                    "access_token": "token",
-                    "realm": "realm",
-                    "machine_name": "machine",
-                },
-            ),
-            (
-                CalculQuebecClient,
-                {
-                    "host": "host",
-                    "user": "user",
-                    "token": "token",
-                    "machine_name": "machine",
-                },
-            ),
-            (MonarqClient, {"host": "host", "user": "user", "access_token": "token"}),
-        ],
-    )
-    def test_all_clients_require_project_parameter(self, client_class, params):
-        """Test that all client types require either project_name or project_id."""
-        with pytest.raises(
-            ProjectParameterError,
-            match="Either project_name or project_id must be provided",
-        ):
-            client_class(**params)
+    def test_project_name_is_readonly(self, basic_client_params, project_name):
+        """Test that project_name is read-only after initialization."""
+        client = ApiClient(**basic_client_params, project_name=project_name)
+        with pytest.raises(AttributeError):
+            client.project_name = "new_project"
+
+    def test_project_id_is_writable(self, basic_client_params, project_id):
+        """Test that project_id can be set after initialization."""
+        client = ApiClient(**basic_client_params, project_id=project_id)
+        assert client.project_id == project_id
+        client.project_id = "new_project_id"
+        assert client.project_id == "new_project_id"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -81,6 +81,7 @@ class TestApiClient:
         assert client.machine_name == basic_client_params["machine_name"]
         assert client.project_name == project_name
         assert client.project_id == ""
+        assert client.circuit_name == "none"
 
     def test_api_client_initialization_with_project_id(
         self, basic_client_params, project_id

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -33,6 +33,12 @@ def project_id():
 
 
 @pytest.fixture
+def circuit_name():
+    """Standard circuit name for testing."""
+    return "test_circuit"
+
+
+@pytest.fixture
 def calcul_quebec_params():
     """Parameters specific to CalculQuebecClient."""
     return {
@@ -115,6 +121,23 @@ class TestApiClient:
         assert isinstance(client.machine_name, str)
         assert isinstance(client.project_name, str)
         assert isinstance(client.project_id, str)
+        assert isinstance(client.circuit_name, str)
+
+    def test_api_client_circuit_name_initialization(
+        self, basic_client_params, project_name, circuit_name
+    ):
+        """Test that ApiClient initializes correctly with circuit_name."""
+        client = ApiClient(
+            **basic_client_params, project_name=project_name, circuit_name=circuit_name
+        )
+        assert client.circuit_name == circuit_name
+
+    def test_api_client_circuit_name_defaults_to_empty_string(
+        self, basic_client_params, project_name
+    ):
+        """Test that circuit_name defaults to empty string when not provided."""
+        client = ApiClient(**basic_client_params, project_name=project_name)
+        assert client.circuit_name == ""
 
 
 class TestCalculQuebecClient:
@@ -254,6 +277,7 @@ class TestMonarqClient:
         assert hasattr(client, "machine_name")
         assert hasattr(client, "project_name")
         assert hasattr(client, "project_id")
+        assert hasattr(client, "circuit_name")
 
 
 class TestProjectParameterValidation:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,293 @@
+from pennylane_calculquebec.API.client import (
+    ApiClient,
+    CalculQuebecClient,
+    MonarqClient,
+    ProjectParameterError,
+)
+import pytest
+
+
+# Test fixtures for common test data
+@pytest.fixture
+def basic_client_params():
+    """Basic parameters for client initialization."""
+    return {
+        "host": "https://example.com",
+        "user": "test_user",
+        "access_token": "test_token_123",
+        "realm": "test_realm",
+        "machine_name": "test_machine",
+    }
+
+
+@pytest.fixture
+def project_name():
+    """Standard project name for testing."""
+    return "test_project"
+
+
+@pytest.fixture
+def project_id():
+    """Standard project ID for testing."""
+    return "project_123"
+
+
+@pytest.fixture
+def calcul_quebec_params():
+    """Parameters specific to CalculQuebecClient."""
+    return {
+        "host": "https://calculquebec.example.com",
+        "user": "cq_user",
+        "token": "cq_token_456",
+        "machine_name": "cq_machine",
+    }
+
+
+@pytest.fixture
+def monarq_params():
+    """Parameters specific to MonarqClient."""
+    return {
+        "host": "https://monarq.example.com",
+        "user": "monarq_user",
+        "access_token": "monarq_token_789",
+    }
+
+
+@pytest.fixture
+def all_client_classes():
+    """List of all client classes for parametrized tests."""
+    return [ApiClient, CalculQuebecClient, MonarqClient]
+
+
+class TestApiClient:
+    """Test cases for the base ApiClient class."""
+
+    def test_api_client_initialization_with_project_name(
+        self, basic_client_params, project_name
+    ):
+        """Test that ApiClient initializes correctly with project_name."""
+        client = ApiClient(**basic_client_params, project_name=project_name)
+
+        assert client.host == basic_client_params["host"]
+        assert client.user == basic_client_params["user"]
+        assert client.access_token == basic_client_params["access_token"]
+        assert client.realm == basic_client_params["realm"]
+        assert client.machine_name == basic_client_params["machine_name"]
+        assert client.project_name == project_name
+        assert client.project_id == ""
+
+    def test_api_client_initialization_with_project_id(
+        self, basic_client_params, project_id
+    ):
+        """Test that ApiClient initializes correctly with project_id."""
+        client = ApiClient(**basic_client_params, project_id=project_id)
+
+        assert client.project_id == project_id
+        assert client.project_name == ""
+
+    def test_api_client_requires_project_parameter(self, basic_client_params):
+        """Test that ApiClient raises error when neither project_name nor project_id is provided."""
+        with pytest.raises(
+            ProjectParameterError,
+            match="Either project_name or project_id must be provided",
+        ):
+            ApiClient(**basic_client_params)
+
+    def test_api_client_project_id_takes_precedence(
+        self, basic_client_params, project_name, project_id
+    ):
+        """Test that when both project_name and project_id are provided, project_id is used."""
+        client = ApiClient(
+            **basic_client_params, project_name=project_name, project_id=project_id
+        )
+
+        assert client.project_id == project_id
+        assert client.project_name == ""
+
+    def test_api_client_attributes_are_strings(self, basic_client_params, project_name):
+        """Test that all ApiClient attributes accept string values."""
+        client = ApiClient(**basic_client_params, project_name=project_name)
+
+        assert isinstance(client.host, str)
+        assert isinstance(client.user, str)
+        assert isinstance(client.access_token, str)
+        assert isinstance(client.realm, str)
+        assert isinstance(client.machine_name, str)
+        assert isinstance(client.project_name, str)
+        assert isinstance(client.project_id, str)
+
+
+class TestCalculQuebecClient:
+    """Test cases for the CalculQuebecClient class."""
+
+    def test_calcul_quebec_client_initialization_with_project_name(
+        self, calcul_quebec_params, project_name
+    ):
+        """Test that CalculQuebecClient initializes correctly with project_name."""
+        client = CalculQuebecClient(**calcul_quebec_params, project_name=project_name)
+
+        assert client.host == calcul_quebec_params["host"]
+        assert client.user == calcul_quebec_params["user"]
+        assert client.access_token == calcul_quebec_params["token"]
+        assert client.realm == "calculqc"
+        assert client.machine_name == calcul_quebec_params["machine_name"]
+        assert client.project_name == project_name
+        assert client.project_id == ""
+
+    def test_calcul_quebec_client_initialization_with_project_id(
+        self, calcul_quebec_params, project_id
+    ):
+        """Test that CalculQuebecClient initializes correctly with project_id."""
+        client = CalculQuebecClient(**calcul_quebec_params, project_id=project_id)
+
+        assert client.project_id == project_id
+        assert client.project_name == ""
+        assert client.realm == "calculqc"
+
+    def test_calcul_quebec_client_requires_project_parameter(
+        self, calcul_quebec_params
+    ):
+        """Test that CalculQuebecClient raises error when no project parameter is provided."""
+        with pytest.raises(
+            ProjectParameterError,
+            match="Either project_name or project_id must be provided",
+        ):
+            CalculQuebecClient(**calcul_quebec_params)
+
+    def test_calcul_quebec_client_project_id_precedence(
+        self, calcul_quebec_params, project_name, project_id
+    ):
+        """Test that project_id takes precedence over project_name in CalculQuebecClient."""
+        client = CalculQuebecClient(
+            **calcul_quebec_params, project_name=project_name, project_id=project_id
+        )
+
+        assert client.project_id == project_id
+        assert client.project_name == ""
+
+    def test_calcul_quebec_client_inherits_from_api_client(
+        self, calcul_quebec_params, project_name
+    ):
+        """Test that CalculQuebecClient is a subclass of ApiClient."""
+        client = CalculQuebecClient(**calcul_quebec_params, project_name=project_name)
+        assert isinstance(client, ApiClient)
+
+    def test_calcul_quebec_client_realm_is_fixed(
+        self, calcul_quebec_params, project_name
+    ):
+        """Test that CalculQuebecClient always sets realm to 'calculqc'."""
+        client = CalculQuebecClient(**calcul_quebec_params, project_name=project_name)
+        assert client.realm == "calculqc"
+
+
+class TestMonarqClient:
+    """Test cases for the MonarqClient class."""
+
+    def test_monarq_client_initialization_with_project_name(
+        self, monarq_params, project_name
+    ):
+        """Test that MonarqClient initializes correctly with project_name."""
+        client = MonarqClient(**monarq_params, project_name=project_name)
+
+        assert client.host == monarq_params["host"]
+        assert client.user == monarq_params["user"]
+        assert client.access_token == monarq_params["access_token"]
+        assert client.realm == "calculqc"
+        assert client.machine_name == "yamaska"
+        assert client.project_name == project_name
+        assert client.project_id == ""
+
+    def test_monarq_client_initialization_with_project_id(
+        self, monarq_params, project_id
+    ):
+        """Test that MonarqClient initializes correctly with project_id."""
+        client = MonarqClient(**monarq_params, project_id=project_id)
+
+        assert client.project_id == project_id
+        assert client.project_name == ""
+        assert client.machine_name == "yamaska"
+        assert client.realm == "calculqc"
+
+    def test_monarq_client_requires_project_parameter(self, monarq_params):
+        """Test that MonarqClient raises error when no project parameter is provided."""
+        with pytest.raises(
+            ProjectParameterError,
+            match="Either project_name or project_id must be provided",
+        ):
+            MonarqClient(**monarq_params)
+
+    def test_monarq_client_project_id_precedence(
+        self, monarq_params, project_name, project_id
+    ):
+        """Test that project_id takes precedence over project_name in MonarqClient."""
+        client = MonarqClient(
+            **monarq_params, project_name=project_name, project_id=project_id
+        )
+
+        assert client.project_id == project_id
+        assert client.project_name == ""
+
+    def test_monarq_client_inherits_from_calcul_quebec_client(
+        self, monarq_params, project_name
+    ):
+        """Test that MonarqClient is a subclass of CalculQuebecClient."""
+        client = MonarqClient(**monarq_params, project_name=project_name)
+        assert isinstance(client, CalculQuebecClient)
+        assert isinstance(client, ApiClient)
+
+    def test_monarq_client_machine_name_is_fixed(self, monarq_params, project_name):
+        """Test that MonarqClient always sets machine_name to 'yamaska'."""
+        client = MonarqClient(**monarq_params, project_name=project_name)
+        assert client.machine_name == "yamaska"
+
+    def test_monarq_client_inheritance_chain(self, monarq_params, project_name):
+        """Test the complete inheritance chain for MonarqClient.
+        i.e. MonarqClient --|> CalculQuebecClient --|> ApiClient
+        """
+        client = MonarqClient(**monarq_params, project_name=project_name)
+
+        # Test that it has all the expected attributes from parent classes
+        assert hasattr(client, "host")
+        assert hasattr(client, "user")
+        assert hasattr(client, "access_token")
+        assert hasattr(client, "realm")
+        assert hasattr(client, "machine_name")
+        assert hasattr(client, "project_name")
+        assert hasattr(client, "project_id")
+
+
+class TestProjectParameterValidation:
+    """Test cases for project_name and project_id validation rules across all clients."""
+
+    @pytest.mark.parametrize(
+        "client_class,params",
+        [
+            (
+                ApiClient,
+                {
+                    "host": "host",
+                    "user": "user",
+                    "access_token": "token",
+                    "realm": "realm",
+                    "machine_name": "machine",
+                },
+            ),
+            (
+                CalculQuebecClient,
+                {
+                    "host": "host",
+                    "user": "user",
+                    "token": "token",
+                    "machine_name": "machine",
+                },
+            ),
+            (MonarqClient, {"host": "host", "user": "user", "access_token": "token"}),
+        ],
+    )
+    def test_all_clients_require_project_parameter(self, client_class, params):
+        """Test that all client types require either project_name or project_id."""
+        with pytest.raises(
+            ProjectParameterError,
+            match="Either project_name or project_id must be provided",
+        ):
+            client_class(**params)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -16,7 +16,6 @@ def basic_client_params():
         "user": "test_user",
         "access_token": "test_token_123",
         "realm": "test_realm",
-        "machine_name": "test_machine",
     }
 
 
@@ -45,7 +44,6 @@ def calcul_quebec_params():
         "host": "https://calculquebec.example.com",
         "user": "cq_user",
         "token": "cq_token_456",
-        "machine_name": "cq_machine",
     }
 
 
@@ -78,10 +76,10 @@ class TestApiClient:
         assert client.user == basic_client_params["user"]
         assert client.access_token == basic_client_params["access_token"]
         assert client.realm == basic_client_params["realm"]
-        assert client.machine_name == basic_client_params["machine_name"]
         assert client.project_name == project_name
         assert client.project_id == ""
         assert client.circuit_name == "none"
+        assert client.machine_name == ""  # Machine name is set later
 
     def test_api_client_initialization_with_project_id(
         self, basic_client_params, project_id
@@ -138,7 +136,7 @@ class TestApiClient:
     ):
         """Test that circuit_name defaults to empty string when not provided."""
         client = ApiClient(**basic_client_params, project_name=project_name)
-        assert client.circuit_name == ""
+        assert client.circuit_name == "none"
 
 
 class TestCalculQuebecClient:
@@ -154,7 +152,7 @@ class TestCalculQuebecClient:
         assert client.user == calcul_quebec_params["user"]
         assert client.access_token == calcul_quebec_params["token"]
         assert client.realm == "calculqc"
-        assert client.machine_name == calcul_quebec_params["machine_name"]
+        assert client.machine_name == ""
         assert client.project_name == project_name
         assert client.project_id == ""
 
@@ -217,7 +215,7 @@ class TestMonarqClient:
         assert client.user == monarq_params["user"]
         assert client.access_token == monarq_params["access_token"]
         assert client.realm == "calculqc"
-        assert client.machine_name == "yamaska"
+        assert client.machine_name == ""
         assert client.project_name == project_name
         assert client.project_id == ""
 
@@ -229,7 +227,7 @@ class TestMonarqClient:
 
         assert client.project_id == project_id
         assert client.project_name == ""
-        assert client.machine_name == "yamaska"
+        assert client.machine_name == ""
         assert client.realm == "calculqc"
 
     def test_monarq_client_requires_project_parameter(self, monarq_params):
@@ -258,11 +256,6 @@ class TestMonarqClient:
         client = MonarqClient(**monarq_params, project_name=project_name)
         assert isinstance(client, CalculQuebecClient)
         assert isinstance(client, ApiClient)
-
-    def test_monarq_client_machine_name_is_fixed(self, monarq_params, project_name):
-        """Test that MonarqClient always sets machine_name to 'yamaska'."""
-        client = MonarqClient(**monarq_params, project_name=project_name)
-        assert client.machine_name == "yamaska"
 
     def test_monarq_client_inheritance_chain(self, monarq_params, project_name):
         """Test the complete inheritance chain for MonarqClient.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,13 +28,16 @@ def mock_get_connectivity():
 
 def test_monarq_default(mock_get_connectivity):
     config = MonarqDefaultConfig("yamaska", False)
-    client = MonarqClient("test", "test", "test")
+    client = MonarqClient(
+        "test",
+        "test",
+        "test",
+        project_id="test_project_id",
+        circuit_name="test_circuit",
+    )
     dev = qml.device(
         "monarq.default", wires=[0], client=client, shots=1000, processing_config=config
     )
-
-    dev.circuit_name = "test_name"
-    dev.project_name = "test_name"
 
     qnode = qml.QNode(circuit, dev)
     with patch("requests.post") as post:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,7 +38,8 @@ def test_monarq_default(mock_get_connectivity):
     dev = qml.device(
         "monarq.default", wires=[0], client=client, shots=1000, processing_config=config
     )
-
+    assert dev._client is client
+    assert dev._client.machine_name == dev.machine_name
     qnode = qml.QNode(circuit, dev)
     with patch("requests.post") as post:
         post.return_value = Response('{"job" : {"id" : 1}}')

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -50,12 +50,10 @@ def mock_convert_circut():
         yield convert_circuit
 
 
-@pytest.fixture(name="mock_create_job")
-def mock_create_job():
-    with patch(
-        "pennylane_calculquebec.API.adapter.ApiAdapter.create_job"
-    ) as create_job:
-        yield create_job
+@pytest.fixture(name="mock_post_job")
+def mock_post_job():
+    with patch("pennylane_calculquebec.API.adapter.ApiAdapter.post_job") as post_job:
+        yield post_job
 
 
 @pytest.fixture(name="mock_job_by_id")
@@ -64,7 +62,7 @@ def mock_job_by_id():
         yield job_by_id
 
 
-def test_run(mock_convert_circuit, mock_create_job, mock_job_by_id):
+def test_run(mock_convert_circuit, mock_post_job, mock_job_by_id):
     test_job_str = '{"job" : {"id" : 3}}'
     test_error_str = '{"code" : 400, "error" : "this is an error"}'
 
@@ -79,16 +77,16 @@ def test_run(mock_convert_circuit, mock_create_job, mock_job_by_id):
 
     ApiAdapter.initialize(client)
 
-    mock_create_job.return_value.status_code = 400
-    mock_create_job.return_value.text = test_error_str
+    mock_post_job.return_value.status_code = 400
+    mock_post_job.return_value.text = test_error_str
 
     # create job => code 400
     Circuit.i = 0
     with pytest.raises(JobException):
         result = Job(Circuit(), "yamaska", "circuit", "project").run()
 
-    mock_create_job.return_value.status_code = 200
-    mock_create_job.return_value.text = test_job_str
+    mock_post_job.return_value.status_code = 200
+    mock_post_job.return_value.text = test_job_str
     mock_job_by_id.side_effect = side_effect_generator(200)
 
     # typical flow

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from pennylane_calculquebec.API.job import Job, JobException
 import json
 
-client = MonarqClient("test", "test", "test")
+client = MonarqClient("test", "test", "test", project_id="test_project_id")
 
 
 class Response_JobById:

--- a/tests/test_monarq_backup.py
+++ b/tests/test_monarq_backup.py
@@ -15,7 +15,7 @@ from pennylane_calculquebec.base_device import BaseDevice
 import pennylane_calculquebec.API.job as api_job
 
 
-client = MonarqClient("host", "user", "token")
+client = MonarqClient("test", "test", "test", project_id="test_project_id")
 
 
 @pytest.fixture

--- a/tests/test_monarq_device.py
+++ b/tests/test_monarq_device.py
@@ -15,7 +15,7 @@ from pennylane_calculquebec.base_device import BaseDevice
 import pennylane_calculquebec.API.job as api_job
 
 
-client = MonarqClient("host", "user", "token")
+client = MonarqClient("host", "user", "token", project_id="test_project_id")
 
 
 @pytest.fixture

--- a/tests/test_monarq_device.py
+++ b/tests/test_monarq_device.py
@@ -79,6 +79,13 @@ def test_constructor(mock_api_initialize):
     assert dev._processing_config is config
 
 
+def test_device_registers_client():
+    """Test that MonarqDevice registers the client when initialized."""
+    dev = MonarqDevice(client=client, shots=1000)
+    assert hasattr(dev, "_client")
+    assert isinstance(dev._client, MonarqClient)
+
+
 def test_preprocess(mock_PreProcessor_get_processor, mock_api_initialize):
     mock_PreProcessor_get_processor.return_value = transform(lambda tape: tape)
     dev = MonarqDevice(client=client, shots=1000)

--- a/tests/test_monarq_fake.py
+++ b/tests/test_monarq_fake.py
@@ -12,7 +12,7 @@ from pennylane_calculquebec.base_device import BaseDevice
 import pennylane_calculquebec.API.job as api_job
 
 
-client = MonarqClient("host", "user", "token")
+client = MonarqClient("test", "test", "test", project_id="test_project_id")
 
 
 @pytest.fixture

--- a/tests/test_monarq_fake.py
+++ b/tests/test_monarq_fake.py
@@ -105,6 +105,12 @@ def test_execute(mock_measure):
     assert mock_measure.call_count == 4
 
 
+def test_monarqsim_without_client():
+    """Test that MonarqSim does not require a client."""
+    sim = MonarqSim(shots=1000)
+    assert not hasattr(sim, "_client")
+
+
 def test_measure(mock_PostProcessor_get_processor, mock_gate_noise, mock_readout_noise):
     from pennylane.tape import QuantumTape
 


### PR DESCRIPTION
## Description



## Problème résolu / Fonctionnalité ajoutée



## Comment tester

Les tests en échec sont des tests qui échouait au moment de branch out.

<img width="1419" height="344" alt="image" src="https://github.com/user-attachments/assets/9bfb15cd-6627-4091-9482-918558619389" />


## Numéro de l'issue associée

resolve #174 

## Autres informations

<!-- Ajoutez toute autre information pertinente. -->
