### PR TITLE
Avis de désapprobation de MonarqClient

### DIFF
--- a/pennylane_calculquebec/API/client.py
+++ b/pennylane_calculquebec/API/client.py
@@ -170,3 +170,10 @@ class MonarqClient(CalculQuebecClient):
             project_id,
             circuit_name,
         )
+        import warnings
+
+        warnings.warn(
+            "MonarqClient is deprecated and will be removed in a future release. Use CalculQuebecClient instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        ),

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -273,6 +273,11 @@ class TestMonarqClient:
         assert hasattr(client, "project_id")
         assert hasattr(client, "circuit_name")
 
+    def test_deprecation_warning(self, monarq_params, project_name):
+        """Test that MonarqClient raises a deprecation warning when initialized."""
+        with pytest.warns(DeprecationWarning):
+            MonarqClient(**monarq_params, project_name=project_name)
+
 
 class TestProjectParameterValidation:
     """Test cases for project_name and project_id validation rules at Parent class level."""


### PR DESCRIPTION
## Description

`MonarqClient` ne comporte plus de différence avec sa classe parente `CalculQuebecClient`, et doit lancer un avertissement.

Notes à propos des warnings:
-  Au moment de cette PR, il n'y pas de standard pour centraliser l'import des avertissements dans le projet, alors le module `warnings` est importé où il est requis seulement.
- Le `stacklevel=2` est le standard pour les avis de désapprobation, indiquant à l'utilisateur que c'est *son* code qui devra subir un changement dans le futur.

## Problème résolu / Fonctionnalité ajoutée

MonarqClient lance un avertissement à son instanciation.

## Comment tester

Créer une instance de `MonarqClient`

## Autres informations
- https://docs.python.org/3/library/warnings.html#testing-warnings
- https://docs.python.org/3/library/warnings.html#warnings.warn
- https://docs.python.org/3/library/exceptions.html#DeprecationWarning
