### PR TITLE
Changement de nom d'attribut de la classe CalculQuebecClient

### DIFF
--- a/pennylane_calculquebec/API/client.py
+++ b/pennylane_calculquebec/API/client.py
@@ -121,7 +121,7 @@ class CalculQuebecClient(ApiClient):
         self,
         host,
         user,
-        token,
+        access_token,
         project_name="",
         project_id="",
         circuit_name="",
@@ -129,7 +129,7 @@ class CalculQuebecClient(ApiClient):
         super().__init__(
             host,
             user,
-            token,
+            access_token,
             "calculqc",
             project_name,
             project_id,

--- a/tests/API/test_api_adapter.py
+++ b/tests/API/test_api_adapter.py
@@ -4,13 +4,13 @@ from pennylane_calculquebec.API.adapter import (
     MultipleProjectsException,
     NoProjectFoundException,
 )
-from pennylane_calculquebec.API.client import MonarqClient
+from pennylane_calculquebec.API.client import CalculQuebecClient
 import pytest
 from unittest.mock import patch
 from pennylane_calculquebec.utility.api import ApiUtility, keys
 from datetime import datetime, timedelta
 
-client = MonarqClient("test", "test", "test", project_id="123")
+client = CalculQuebecClient("test", "test", "test", project_id="123")
 
 
 # ------------ MOCKS ----------------------

--- a/tests/API/test_job.py
+++ b/tests/API/test_job.py
@@ -1,11 +1,11 @@
 from pennylane_calculquebec.API.adapter import ApiAdapter
-from pennylane_calculquebec.API.client import MonarqClient
+from pennylane_calculquebec.API.client import CalculQuebecClient
 import pytest
 from unittest.mock import patch
 from pennylane_calculquebec.API.job import Job, JobException
 import json
 
-client = MonarqClient("test", "test", "test", project_id="test_project_id")
+client = CalculQuebecClient("test", "test", "test", project_id="test_project_id")
 
 
 class Response_JobById:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -43,7 +43,7 @@ def calcul_quebec_params():
     return {
         "host": "https://calculquebec.example.com",
         "user": "cq_user",
-        "token": "cq_token_456",
+        "access_token": "cq_token_456",
     }
 
 
@@ -150,7 +150,7 @@ class TestCalculQuebecClient:
 
         assert client.host == calcul_quebec_params["host"]
         assert client.user == calcul_quebec_params["user"]
-        assert client.access_token == calcul_quebec_params["token"]
+        assert client.access_token == calcul_quebec_params["access_token"]
         assert client.realm == "calculqc"
         assert client.machine_name == ""
         assert client.project_name == project_name

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,5 @@
 import pennylane as qml
-from pennylane_calculquebec.API.client import MonarqClient
+from pennylane_calculquebec.API.client import CalculQuebecClient
 import pytest
 from unittest.mock import patch
 import pennylane_calculquebec.monarq_data as data
@@ -28,7 +28,7 @@ def mock_get_connectivity():
 
 def test_monarq_default(mock_get_connectivity):
     config = MonarqDefaultConfig("yamaska", False)
-    client = MonarqClient(
+    client = CalculQuebecClient(
         "test",
         "test",
         "test",

--- a/tests/test_monarq_backup.py
+++ b/tests/test_monarq_backup.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 from pennylane_calculquebec.monarq_backup import MonarqBackup, DeviceException
-from pennylane_calculquebec.API.client import MonarqClient
+from pennylane_calculquebec.API.client import CalculQuebecClient
 from pennylane_calculquebec.processing.config import (
     MonarqDefaultConfig,
     NoPlaceNoRouteConfig,
@@ -15,7 +15,7 @@ from pennylane_calculquebec.base_device import BaseDevice
 import pennylane_calculquebec.API.job as api_job
 
 
-client = MonarqClient("test", "test", "test", project_id="test_project_id")
+client = CalculQuebecClient("test", "test", "test", project_id="test_project_id")
 
 
 @pytest.fixture

--- a/tests/test_monarq_device.py
+++ b/tests/test_monarq_device.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 from pennylane_calculquebec.monarq_device import MonarqDevice, DeviceException
-from pennylane_calculquebec.API.client import MonarqClient
+from pennylane_calculquebec.API.client import CalculQuebecClient
 from pennylane_calculquebec.processing.config import (
     MonarqDefaultConfig,
     NoPlaceNoRouteConfig,
@@ -15,7 +15,7 @@ from pennylane_calculquebec.base_device import BaseDevice
 import pennylane_calculquebec.API.job as api_job
 
 
-client = MonarqClient("host", "user", "token", project_id="test_project_id")
+client = CalculQuebecClient("host", "user", "token", project_id="test_project_id")
 
 
 @pytest.fixture
@@ -83,7 +83,7 @@ def test_device_registers_client():
     """Test that MonarqDevice registers the client when initialized."""
     dev = MonarqDevice(client=client, shots=1000)
     assert hasattr(dev, "_client")
-    assert isinstance(dev._client, MonarqClient)
+    assert isinstance(dev._client, CalculQuebecClient)
 
 
 def test_preprocess(mock_PreProcessor_get_processor, mock_api_initialize):

--- a/tests/test_monarq_fake.py
+++ b/tests/test_monarq_fake.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch
 from pennylane_calculquebec.monarq_sim import MonarqSim, MonarqDefaultConfig
 from pennylane_calculquebec.monarq_device import DeviceException
-from pennylane_calculquebec.API.client import MonarqClient
+from pennylane_calculquebec.API.client import CalculQuebecClient
 from pennylane_calculquebec.processing.config import EmptyConfig
 from pennylane_calculquebec.processing import PreProcessor
 from pennylane.transforms import transform
@@ -12,7 +12,7 @@ from pennylane_calculquebec.base_device import BaseDevice
 import pennylane_calculquebec.API.job as api_job
 
 
-client = MonarqClient("test", "test", "test", project_id="test_project_id")
+client = CalculQuebecClient("test", "test", "test", project_id="test_project_id")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Cette PR change l'attribut `token` de la classe `CalculQuebecClient` pour `access_token`, à l'instar de sa classe parente.

La PR change également les références de `MonarqClient` dans les tests unitaires afin de remplacer son usage par `CalculQuebecClient`. Cela valide par le fait même que les deux classes sont équialentes.
